### PR TITLE
Remove rank plot as temporary fix for OHDSI symposium

### DIFF
--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -86,14 +86,14 @@ bodyTabs <- shinydashboard::tabItems(
           column(
             width = 3,
             shiny::actionButton(inputId = "getResults", "Suggest Comparators")
-          ),
-          column(
-            width = 9,
-            conditionalPanel(
-              "input.selectedExposure != ''",
-              shiny::actionButton(inputId = "showRankings", "Show rank plot"),
-            )
-          )
+          )#,
+          # column(
+          #   width = 9,
+          #   conditionalPanel(
+          #     "input.selectedExposure != ''",
+          #     shiny::actionButton(inputId = "showRankings", "Show rank plot"),
+          #   )
+          # )
         )
       ),
       shiny::conditionalPanel(


### PR DESCRIPTION
Since the problems mentioned in [issue #10 ](https://github.com/OHDSI/ComparatorSelectionExplorer/issues/10) still elude us, let's temporarily remove the ui for the rank plot so no one gets confused, particularly during the symposium software demo.
