### PR TITLE
Update SelectiveFeatureExtraction.sql

### DIFF
--- a/inst/sql/sql_server/SelectiveFeatureExtraction.sql
+++ b/inst/sql/sql_server/SelectiveFeatureExtraction.sql
@@ -252,9 +252,6 @@ where 1.0*t1.num_persons/scd1.num_persons >= 0.01
 and t1.drug_concept_id > 0
 ;
 
-select * from #cov_summary;
-
-
 insert into @results_database_schema.@covariate_means_table (cohort_definition_id, covariate_id, covariate_mean)
 select cohort_definition_id, covariate_id, covariate_mean from #cov_summary;
 


### PR DESCRIPTION
Removed errant statement "select * from #cov_summary" that was causing errors in generateSimilarityScores().

Edit: sorry, just realized you got rid of this in the develop branch already. Please merge one into main.